### PR TITLE
Convert method toHtml with swagger argument to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In your pom.xml, add the following:
 		<dependency>
 			<groupId>com.github.chenjianjx</groupId>
 			<artifactId>swagger2html</artifactId>
-			<version>2.0.1</version>
+			<version>2.0.2</version>
 		</dependency>
 		...
 	</dependencies>	

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.chenjianjx</groupId>
 	<artifactId>swagger2html</artifactId>
-	<version>2.0.1</version>
+	<version>2.0.2</version>
 	<name>Swagger to Html</name>
 	<description>A java tool to convert swagger json to readable doc</description>
 	<url>https://github.com/chenjianjx/swagger2html</url>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
 		</dependency>
 
 
-
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>

--- a/src/main/java/org/swagger2html/Swagger2Html.java
+++ b/src/main/java/org/swagger2html/Swagger2Html.java
@@ -51,7 +51,7 @@ public class Swagger2Html {
 		toHtml(swagger, cssToInclude, out);
 	}
 
-	private void toHtml(Swagger swagger, String cssToInclude, Writer out)
+	public void toHtml(Swagger swagger, String cssToInclude, Writer out)
 			throws IOException {
 		Template template = freemarkerFactory
 				.getClasspathTemplate("/single-html.ftl");


### PR DESCRIPTION
Can be useful when you try to read some swagger.json on a https page, where yo must set spefic things on the SwaggerParser Object .
If you prefer, another solution can be to add a setter instead to change the private method to public.